### PR TITLE
fix: use table-prefixed names for inline unique constraints

### DIFF
--- a/src/core/schema/parser/tables/constraint-parser.ts
+++ b/src/core/schema/parser/tables/constraint-parser.ts
@@ -51,7 +51,7 @@ export function extractAllConstraints(
               if (check) checkConstraints.push(check);
             } else if (contype === "CONSTR_UNIQUE") {
               uniqueConstraints.push({
-                name: c.Constraint.conname || `${colName}_unique`,
+                name: c.Constraint.conname,
                 columns: [colName],
               });
             } else if (contype === "CONSTR_FOREIGN") {


### PR DESCRIPTION
## Summary

- Remove fallback name generation from constraint parser for column-level UNIQUE constraints
- Let sql.ts generate table-prefixed names (`${table}_${col}_unique`) instead of parser's `${col}_unique`
- Add test for multiple tables with same column name using inline UNIQUE

## Context

Commit 00fcbf1 fixed sql.ts to generate table-prefixed constraint names, but missed the parser which was still overriding with `${colName}_unique`. This caused duplicate constraint name errors when multiple tables had columns with the same name using inline UNIQUE syntax.

Generated with [Claude Code](https://claude.com/claude-code)