### PR TITLE
refactor: extract handlers from SchemaService

### DIFF
--- a/src/core/schema/handlers/comment-handler.ts
+++ b/src/core/schema/handlers/comment-handler.ts
@@ -1,0 +1,53 @@
+import type { Comment } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import { SQLBuilder } from "../../../utils/sql-builder";
+
+export class CommentHandler {
+  generateStatements(desiredComments: Comment[], currentComments: Comment[]): string[] {
+    const statements: string[] = [];
+    const currentCommentMap = new Map(
+      currentComments.map(c => [this.getCommentKey(c), c])
+    );
+
+    for (const desiredComment of desiredComments) {
+      const key = this.getCommentKey(desiredComment);
+      const currentComment = currentCommentMap.get(key);
+
+      if (!currentComment || currentComment.comment !== desiredComment.comment) {
+        const sql = this.generateCommentSQL(desiredComment);
+        statements.push(sql);
+        Logger.info(`${currentComment ? 'Updating' : 'Creating'} comment on ${desiredComment.objectType} '${desiredComment.objectName}'`);
+      } else {
+        Logger.info(`Comment on ${desiredComment.objectType} '${desiredComment.objectName}' is up to date, skipping`);
+      }
+    }
+
+    return statements;
+  }
+
+  private getCommentKey(comment: Comment): string {
+    if (comment.objectType === 'COLUMN') {
+      const schemaPrefix = comment.schemaName || 'public';
+      return `${comment.objectType}:${schemaPrefix}.${comment.objectName}.${comment.columnName}`;
+    }
+    return `${comment.objectType}:${comment.schemaName || 'public'}.${comment.objectName}`;
+  }
+
+  private generateCommentSQL(comment: Comment): string {
+    const escapedComment = comment.comment.replace(/'/g, "''");
+    const builder = new SQLBuilder().p("COMMENT ON");
+
+    if (comment.objectType === 'SCHEMA') {
+      builder.p("SCHEMA").ident(comment.objectName);
+    } else if (comment.objectType === 'COLUMN') {
+      builder.p("COLUMN").table(comment.objectName, comment.schemaName);
+      builder.rewriteLastChar('.');
+      builder.ident(comment.columnName!);
+    } else {
+      builder.p(comment.objectType).table(comment.objectName, comment.schemaName);
+    }
+
+    builder.p(`IS '${escapedComment}'`);
+    return builder.build() + ';';
+  }
+}

--- a/src/core/schema/handlers/enum-handler.ts
+++ b/src/core/schema/handlers/enum-handler.ts
@@ -1,0 +1,123 @@
+import { Client } from "pg";
+import type { EnumType } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import { SQLBuilder } from "../../../utils/sql-builder";
+import {
+  generateCreateTypeSQL,
+  generateDropTypeSQL,
+} from "../../../utils/sql";
+
+export class EnumHandler {
+  generateStatements(desiredEnums: EnumType[], currentEnums: EnumType[]): {
+    transactional: string[];
+    concurrent: string[];
+  } {
+    const transactional: string[] = [];
+    const concurrent: string[] = [];
+    const currentEnumMap = new Map(currentEnums.map(e => [e.name, e]));
+
+    for (const desiredEnum of desiredEnums) {
+      const currentEnum = currentEnumMap.get(desiredEnum.name);
+
+      if (!currentEnum) {
+        transactional.push(generateCreateTypeSQL(desiredEnum));
+      } else {
+        const currentValues = currentEnum.values;
+        const desiredValues = desiredEnum.values;
+
+        if (JSON.stringify(currentValues) === JSON.stringify(desiredValues)) {
+          Logger.info(`ENUM type '${desiredEnum.name}' already exists with matching values, skipping creation`);
+        } else {
+          const modificationStatements = this.generateModificationStatements(desiredEnum, currentEnum);
+          concurrent.push(...modificationStatements);
+        }
+      }
+    }
+
+    return { transactional, concurrent };
+  }
+
+  async generateRemovalStatements(
+    desiredEnums: EnumType[],
+    currentEnums: EnumType[],
+    client: Client,
+    schemas: string[]
+  ): Promise<string[]> {
+    const statements: string[] = [];
+    const desiredEnumNames = new Set(desiredEnums.map(e => e.name));
+
+    for (const currentEnum of currentEnums) {
+      if (!desiredEnumNames.has(currentEnum.name)) {
+        const isUsed = await this.isTypeUsed(currentEnum.name, client, schemas);
+
+        if (!isUsed) {
+          statements.push(generateDropTypeSQL(currentEnum.name, currentEnum.schema));
+          Logger.info(`Dropping unused ENUM type '${currentEnum.name}'`);
+        } else {
+          Logger.warning(
+            `ENUM type '${currentEnum.name}' is not in schema but is still referenced by table columns. ` +
+            `Cannot auto-drop. Remove column references first.`
+          );
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  private generateModificationStatements(desiredEnum: EnumType, currentEnum: EnumType): string[] {
+    const statements: string[] = [];
+    const currentValues = new Set(currentEnum.values);
+    const desiredValues = new Set(desiredEnum.values);
+
+    const valuesToAdd = desiredEnum.values.filter(value => !currentValues.has(value));
+    const valuesToRemove = currentEnum.values.filter(value => !desiredValues.has(value));
+    const valuesIdentical = JSON.stringify(currentEnum.values) === JSON.stringify(desiredEnum.values);
+    const isOnlyAppending = valuesToRemove.length === 0 && valuesToAdd.length > 0 &&
+                           currentEnum.values.every((value, index) => desiredEnum.values[index] === value);
+
+    if (valuesIdentical) {
+      Logger.info(`ENUM type '${desiredEnum.name}' values already match, no changes needed`);
+    } else if (isOnlyAppending) {
+      for (const value of valuesToAdd) {
+        const builder = new SQLBuilder().p("ALTER TYPE");
+        if (desiredEnum.schema) {
+          builder.ident(desiredEnum.schema).rewriteLastChar('.');
+        }
+        builder.ident(desiredEnum.name);
+        builder.p(`ADD VALUE '${value}';`);
+        statements.push(builder.build());
+        Logger.info(`Adding value '${value}' to ENUM type '${desiredEnum.name}'`);
+      }
+    } else {
+      const changeDescription = [];
+      if (valuesToRemove.length > 0) {
+        changeDescription.push(`removing values [${valuesToRemove.join(', ')}]`);
+      }
+      if (valuesToRemove.length === 0 && valuesToAdd.length === 0) {
+        changeDescription.push(`reordering values`);
+      }
+
+      throw new Error(
+        `ENUM type '${desiredEnum.name}' modification requires manual intervention. ` +
+        `Cannot safely perform: ${changeDescription.join(' and ')}. ` +
+        `Current values: [${currentEnum.values.join(', ')}], ` +
+        `Desired values: [${desiredEnum.values.join(', ')}]. ` +
+        `Removing ENUM values or changing their order can cause data loss and is not supported by Terra. ` +
+        `Please handle this migration manually or create a new ENUM type with a different name.`
+      );
+    }
+
+    return statements;
+  }
+
+  private async isTypeUsed(enumName: string, client: Client, schemas: string[]): Promise<boolean> {
+    const result = await client.query(`
+      SELECT COUNT(*) as usage_count
+      FROM information_schema.columns
+      WHERE udt_name = $1 AND table_schema = ANY($2::text[])
+    `, [enumName, schemas]);
+
+    return parseInt(result.rows[0].usage_count) > 0;
+  }
+}

--- a/src/core/schema/handlers/extension-handler.ts
+++ b/src/core/schema/handlers/extension-handler.ts
@@ -1,0 +1,58 @@
+import type { Extension } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import { SQLBuilder } from "../../../utils/sql-builder";
+
+export class ExtensionHandler {
+  generateStatements(desiredExtensions: Extension[], currentExtensions: Extension[]): {
+    create: string[];
+    drop: string[];
+  } {
+    const createStatements: string[] = [];
+    const dropStatements: string[] = [];
+    const currentExtensionMap = new Map(currentExtensions.map(e => [e.name, e]));
+    const desiredExtensionNames = new Set(desiredExtensions.map(e => e.name));
+
+    for (const currentExt of currentExtensions) {
+      if (!desiredExtensionNames.has(currentExt.name)) {
+        const dropBuilder = new SQLBuilder().p("DROP EXTENSION IF EXISTS").ident(currentExt.name).p("CASCADE");
+        dropStatements.push(dropBuilder.build() + ';');
+        Logger.info(`Dropping extension '${currentExt.name}' (CASCADE will drop dependent objects)`);
+      }
+    }
+
+    for (const desiredExt of desiredExtensions) {
+      const currentExt = currentExtensionMap.get(desiredExt.name);
+
+      if (!currentExt) {
+        createStatements.push(this.generateCreateExtensionSQL(desiredExt));
+        Logger.info(`Creating extension '${desiredExt.name}'`);
+      } else {
+        if (desiredExt.version && currentExt.version !== desiredExt.version) {
+          Logger.warning(`Extension '${desiredExt.name}' version differs (current: ${currentExt.version}, desired: ${desiredExt.version}). Manual update may be required.`);
+        } else {
+          Logger.info(`Extension '${desiredExt.name}' already exists, skipping`);
+        }
+      }
+    }
+
+    return { create: createStatements, drop: dropStatements };
+  }
+
+  private generateCreateExtensionSQL(extension: Extension): string {
+    const builder = new SQLBuilder().p("CREATE EXTENSION IF NOT EXISTS").ident(extension.name);
+
+    if (extension.schema) {
+      builder.p("SCHEMA").ident(extension.schema);
+    }
+
+    if (extension.version) {
+      builder.p(`VERSION '${extension.version}'`);
+    }
+
+    if (extension.cascade) {
+      builder.p("CASCADE");
+    }
+
+    return builder.build() + ';';
+  }
+}

--- a/src/core/schema/handlers/function-handler.ts
+++ b/src/core/schema/handlers/function-handler.ts
@@ -1,0 +1,48 @@
+import type { Function } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import {
+  generateCreateFunctionSQL,
+  generateDropFunctionSQL,
+} from "../../../utils/sql";
+
+export class FunctionHandler {
+  generateStatements(desiredFunctions: Function[], currentFunctions: Function[]): string[] {
+    const statements: string[] = [];
+    const currentFunctionMap = new Map(currentFunctions.map(f => [f.name, f]));
+    const desiredFunctionNames = new Set(desiredFunctions.map(f => f.name));
+
+    for (const currentFunc of currentFunctions) {
+      if (!desiredFunctionNames.has(currentFunc.name)) {
+        statements.push(generateDropFunctionSQL(currentFunc));
+        Logger.info(`Dropping function '${currentFunc.name}'`);
+      }
+    }
+
+    for (const desiredFunc of desiredFunctions) {
+      const currentFunc = currentFunctionMap.get(desiredFunc.name);
+
+      if (!currentFunc) {
+        statements.push(generateCreateFunctionSQL(desiredFunc));
+        Logger.info(`Creating function '${desiredFunc.name}'`);
+      } else {
+        if (this.needsUpdate(desiredFunc, currentFunc)) {
+          statements.push(generateDropFunctionSQL(currentFunc));
+          statements.push(generateCreateFunctionSQL(desiredFunc));
+          Logger.info(`Updating function '${desiredFunc.name}'`);
+        } else {
+          Logger.info(`Function '${desiredFunc.name}' is up to date, skipping`);
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  private needsUpdate(desired: Function, current: Function): boolean {
+    const normalizeBody = (body: string) => body.replace(/\s+/g, ' ').trim();
+    return normalizeBody(desired.body) !== normalizeBody(current.body) ||
+           desired.returnType !== current.returnType ||
+           desired.language !== current.language ||
+           desired.volatility !== current.volatility;
+  }
+}

--- a/src/core/schema/handlers/index.ts
+++ b/src/core/schema/handlers/index.ts
@@ -1,0 +1,9 @@
+export { CommentHandler } from "./comment-handler";
+export { EnumHandler } from "./enum-handler";
+export { ExtensionHandler } from "./extension-handler";
+export { FunctionHandler } from "./function-handler";
+export { ProcedureHandler } from "./procedure-handler";
+export { SchemaHandler } from "./schema-handler";
+export { SequenceHandler } from "./sequence-handler";
+export { TriggerHandler } from "./trigger-handler";
+export { ViewHandler } from "./view-handler";

--- a/src/core/schema/handlers/procedure-handler.ts
+++ b/src/core/schema/handlers/procedure-handler.ts
@@ -1,0 +1,46 @@
+import type { Procedure } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import {
+  generateCreateProcedureSQL,
+  generateDropProcedureSQL,
+} from "../../../utils/sql";
+
+export class ProcedureHandler {
+  generateStatements(desiredProcedures: Procedure[], currentProcedures: Procedure[]): string[] {
+    const statements: string[] = [];
+    const currentProcedureMap = new Map(currentProcedures.map(p => [p.name, p]));
+    const desiredProcedureNames = new Set(desiredProcedures.map(p => p.name));
+
+    for (const currentProc of currentProcedures) {
+      if (!desiredProcedureNames.has(currentProc.name)) {
+        statements.push(generateDropProcedureSQL(currentProc));
+        Logger.info(`Dropping procedure '${currentProc.name}'`);
+      }
+    }
+
+    for (const desiredProc of desiredProcedures) {
+      const currentProc = currentProcedureMap.get(desiredProc.name);
+
+      if (!currentProc) {
+        statements.push(generateCreateProcedureSQL(desiredProc));
+        Logger.info(`Creating procedure '${desiredProc.name}'`);
+      } else {
+        if (this.needsUpdate(desiredProc, currentProc)) {
+          statements.push(generateDropProcedureSQL(currentProc));
+          statements.push(generateCreateProcedureSQL(desiredProc));
+          Logger.info(`Updating procedure '${desiredProc.name}'`);
+        } else {
+          Logger.info(`Procedure '${desiredProc.name}' is up to date, skipping`);
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  private needsUpdate(desired: Procedure, current: Procedure): boolean {
+    const normalizeBody = (body: string) => body.replace(/\s+/g, ' ').trim();
+    return normalizeBody(desired.body) !== normalizeBody(current.body) ||
+           desired.language !== current.language;
+  }
+}

--- a/src/core/schema/handlers/schema-handler.ts
+++ b/src/core/schema/handlers/schema-handler.ts
@@ -1,0 +1,31 @@
+import type { SchemaDefinition } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import { SQLBuilder } from "../../../utils/sql-builder";
+
+export class SchemaHandler {
+  generateStatements(desiredSchemas: SchemaDefinition[], currentSchemas: SchemaDefinition[]): string[] {
+    const statements: string[] = [];
+    const currentSchemaNames = new Set(currentSchemas.map(s => s.name));
+
+    for (const desiredSchema of desiredSchemas) {
+      if (!currentSchemaNames.has(desiredSchema.name)) {
+        const builder = new SQLBuilder().p("CREATE SCHEMA");
+        if (desiredSchema.ifNotExists) {
+          builder.p("IF NOT EXISTS");
+        }
+        builder.ident(desiredSchema.name);
+
+        if (desiredSchema.owner) {
+          builder.p("AUTHORIZATION").ident(desiredSchema.owner);
+        }
+
+        statements.push(builder.build() + ';');
+        Logger.info(`Creating schema '${desiredSchema.name}'`);
+      } else {
+        Logger.info(`Schema '${desiredSchema.name}' already exists, skipping`);
+      }
+    }
+
+    return statements;
+  }
+}

--- a/src/core/schema/handlers/sequence-handler.ts
+++ b/src/core/schema/handlers/sequence-handler.ts
@@ -1,0 +1,51 @@
+import type { Sequence } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import {
+  generateCreateSequenceSQL,
+  generateDropSequenceSQL,
+} from "../../../utils/sql";
+
+export class SequenceHandler {
+  generateStatements(desiredSequences: Sequence[], currentSequences: Sequence[]): string[] {
+    const statements: string[] = [];
+    const currentSequenceMap = new Map(currentSequences.map(s => [s.name, s]));
+    const desiredSequenceNames = new Set(desiredSequences.map(s => s.name));
+
+    for (const currentSeq of currentSequences) {
+      if (!desiredSequenceNames.has(currentSeq.name) && !currentSeq.ownedBy) {
+        statements.push(generateDropSequenceSQL(currentSeq.name));
+        Logger.info(`Dropping sequence '${currentSeq.name}'`);
+      }
+    }
+
+    for (const desiredSeq of desiredSequences) {
+      const currentSeq = currentSequenceMap.get(desiredSeq.name);
+
+      if (!currentSeq) {
+        statements.push(generateCreateSequenceSQL(desiredSeq));
+        Logger.info(`Creating sequence '${desiredSeq.name}'`);
+      } else if (!currentSeq.ownedBy) {
+        if (this.needsUpdate(desiredSeq, currentSeq)) {
+          statements.push(generateDropSequenceSQL(currentSeq.name));
+          statements.push(generateCreateSequenceSQL(desiredSeq));
+          Logger.info(`Updating sequence '${desiredSeq.name}'`);
+        } else {
+          Logger.info(`Sequence '${desiredSeq.name}' is up to date, skipping`);
+        }
+      } else {
+        Logger.info(`Sequence '${desiredSeq.name}' is owned by a table column, skipping`);
+      }
+    }
+
+    return statements;
+  }
+
+  private needsUpdate(desired: Sequence, current: Sequence): boolean {
+    return desired.increment !== current.increment ||
+           desired.minValue !== current.minValue ||
+           desired.maxValue !== current.maxValue ||
+           desired.start !== current.start ||
+           desired.cache !== current.cache ||
+           desired.cycle !== current.cycle;
+  }
+}

--- a/src/core/schema/handlers/trigger-handler.ts
+++ b/src/core/schema/handlers/trigger-handler.ts
@@ -1,0 +1,49 @@
+import type { Trigger } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import {
+  generateCreateTriggerSQL,
+  generateDropTriggerSQL,
+} from "../../../utils/sql";
+
+export class TriggerHandler {
+  generateStatements(desiredTriggers: Trigger[], currentTriggers: Trigger[]): string[] {
+    const statements: string[] = [];
+    const currentTriggerMap = new Map(currentTriggers.map(t => [`${t.tableName}.${t.name}`, t]));
+    const desiredTriggerKeys = new Set(desiredTriggers.map(t => `${t.tableName}.${t.name}`));
+
+    for (const currentTrig of currentTriggers) {
+      const key = `${currentTrig.tableName}.${currentTrig.name}`;
+      if (!desiredTriggerKeys.has(key)) {
+        statements.push(generateDropTriggerSQL(currentTrig));
+        Logger.info(`Dropping trigger '${currentTrig.name}' on '${currentTrig.tableName}'`);
+      }
+    }
+
+    for (const desiredTrig of desiredTriggers) {
+      const key = `${desiredTrig.tableName}.${desiredTrig.name}`;
+      const currentTrig = currentTriggerMap.get(key);
+
+      if (!currentTrig) {
+        statements.push(generateCreateTriggerSQL(desiredTrig));
+        Logger.info(`Creating trigger '${desiredTrig.name}' on '${desiredTrig.tableName}'`);
+      } else {
+        if (this.needsUpdate(desiredTrig, currentTrig)) {
+          statements.push(generateDropTriggerSQL(currentTrig));
+          statements.push(generateCreateTriggerSQL(desiredTrig));
+          Logger.info(`Updating trigger '${desiredTrig.name}' on '${desiredTrig.tableName}'`);
+        } else {
+          Logger.info(`Trigger '${desiredTrig.name}' is up to date, skipping`);
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  private needsUpdate(desired: Trigger, current: Trigger): boolean {
+    return desired.timing !== current.timing ||
+           desired.forEach !== current.forEach ||
+           desired.functionName !== current.functionName ||
+           JSON.stringify(desired.events) !== JSON.stringify(current.events);
+  }
+}

--- a/src/core/schema/handlers/view-handler.ts
+++ b/src/core/schema/handlers/view-handler.ts
@@ -1,0 +1,67 @@
+import type { View } from "../../../types/schema";
+import { Logger } from "../../../utils/logger";
+import {
+  generateCreateViewSQL,
+  generateDropViewSQL,
+  generateCreateOrReplaceViewSQL,
+} from "../../../utils/sql";
+
+export class ViewHandler {
+  generateStatements(desiredViews: View[], currentViews: View[]): string[] {
+    const statements: string[] = [];
+    const currentViewMap = new Map(currentViews.map(v => [v.name, v]));
+    const desiredViewNames = new Set(desiredViews.map(v => v.name));
+
+    for (const currentView of currentViews) {
+      if (!desiredViewNames.has(currentView.name)) {
+        statements.push(generateDropViewSQL(currentView.name, currentView.materialized));
+        Logger.info(`Dropping view '${currentView.name}'`);
+      }
+    }
+
+    for (const desiredView of desiredViews) {
+      const currentView = currentViewMap.get(desiredView.name);
+
+      if (!currentView) {
+        statements.push(generateCreateViewSQL(desiredView));
+        Logger.info(`Creating view '${desiredView.name}'`);
+      } else {
+        if (this.needsUpdate(desiredView, currentView)) {
+          statements.push(generateCreateOrReplaceViewSQL(desiredView));
+          Logger.info(`Updating view '${desiredView.name}'`);
+        } else {
+          Logger.info(`View '${desiredView.name}' is up to date, skipping`);
+        }
+      }
+    }
+
+    return statements;
+  }
+
+  private needsUpdate(desired: View, current: View): boolean {
+    if (desired.materialized !== current.materialized) {
+      return true;
+    }
+
+    const normalizeDefinition = (def: string) => def.replace(/\s+/g, ' ').trim();
+    const normalizedDesired = normalizeDefinition(desired.definition);
+    const normalizedCurrent = normalizeDefinition(current.definition);
+
+    if (normalizedDesired !== normalizedCurrent) {
+      Logger.info(`View '${desired.name}' needs update:`);
+      Logger.info(`  Desired: ${normalizedDesired.substring(0, 100)}...`);
+      Logger.info(`  Current: ${normalizedCurrent.substring(0, 100)}...`);
+      return true;
+    }
+
+    if (desired.checkOption !== current.checkOption) {
+      return true;
+    }
+
+    if (desired.securityBarrier !== current.securityBarrier) {
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Extract 9 handler classes from SchemaService (886 -> 324 lines, 63% reduction)
- Each handler encapsulates statement generation for one object type
- SchemaService acts as orchestration facade

## Handlers
- `SchemaHandler` - CREATE SCHEMA statements
- `CommentHandler` - COMMENT ON statements
- `ExtensionHandler` - CREATE/DROP EXTENSION statements
- `EnumHandler` - CREATE/ALTER/DROP TYPE statements (with race condition handling)
- `SequenceHandler` - CREATE/DROP SEQUENCE statements
- `FunctionHandler` - CREATE/DROP FUNCTION statements
- `ProcedureHandler` - CREATE/DROP PROCEDURE statements
- `ViewHandler` - CREATE/DROP VIEW statements
- `TriggerHandler` - CREATE/DROP TRIGGER statements

## Test plan
- [x] All 722 tests pass
- [x] Build succeeds

Closes #46