### PR TITLE
fix: skip schema creation when all its objects are unmanaged

### DIFF
--- a/src/core/schema/service.ts
+++ b/src/core/schema/service.ts
@@ -375,7 +375,7 @@ export class SchemaService {
       triggers: parsed.triggers.filter(t => isManaged(t.schema)),
       sequences: parsed.sequences.filter(s => isManaged(s.schema)),
       extensions: parsed.extensions,
-      schemas: parsed.schemas,
+      schemas: parsed.schemas.filter(s => managedSchemas.includes(s.name)),
       comments: parsed.comments.filter(c => isManaged(c.schemaName)),
     };
   }


### PR DESCRIPTION
## Summary
- Filter schemas in `filterUnmanagedSchemas` to exclude schemas not in the managed schemas list
- Previously schemas were passed through unfiltered even when all their objects were ignored

Closes #74

## Test plan
- [x] Added test that verifies unmanaged schemas are not created
- [x] All existing tests pass (1015 tests)
- [x] Type check passes

Generated with [Claude Code](https://claude.ai/code)