### PR TITLE
fix: partial index idempotency via AST comparison (#80)

### DIFF
--- a/src/core/schema/differ.ts
+++ b/src/core/schema/differ.ts
@@ -780,9 +780,13 @@ export class SchemaDiffer {
       if (index1.columns[i] !== index2.columns[i]) return false;
     }
 
-    const where1 = index1.where ? normalizeExpression(index1.where) : undefined;
-    const where2 = index2.where ? normalizeExpression(index2.where) : undefined;
-    if (where1 !== where2) return false;
+    const where1 = index1.where;
+    const where2 = index2.where;
+    if (where1 && where2) {
+      if (!expressionsEqual(where1, where2)) return false;
+    } else if (where1 !== where2) {
+      return false;
+    }
     if (index1.expression !== index2.expression) return false;
     if (index1.tablespace !== index2.tablespace) return false;
 


### PR DESCRIPTION
## Summary
- Use `expressionsEqual` (AST-based) instead of `normalizeExpression` (regex-based) for WHERE clause comparison in partial indexes
- Fixes issue where PostgreSQL returns parenthesized sub-expressions like `(is_default = true) AND (deleted_at IS NULL)` that regex normalization didn't handle

Closes #80

## Test plan
- [x] Added 3 idempotency tests for partial indexes with boolean/NULL conditions
- [x] All 1018 tests pass

Generated with [Claude Code](https://claude.ai/code)