### PR TITLE
fix: expression indexes with multiple operators not fully wrapped

### DIFF
--- a/src/core/schema/differ.ts
+++ b/src/core/schema/differ.ts
@@ -871,8 +871,8 @@ export class SchemaDiffer {
 
     if (index.expression) {
       let expr = index.expression;
-      const needsInnerParens = !expr.startsWith('(') && /[+\-*/%^&|<>=!]/.test(expr);
-      if (needsInnerParens) {
+      const hasOperators = /[+\-*/%^&|<>=!]/.test(expr);
+      if (hasOperators) {
         expr = `(${expr})`;
       }
       const sortOrder = index.sortOrders?.[0];

--- a/src/test/edge-cases/index-expr.test.ts
+++ b/src/test/edge-cases/index-expr.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Client } from "pg";
+import { createTestClient, cleanDatabase, createTestSchemaService } from "../utils";
+
+describe("Edge case: expression indexes", () => {
+  let client: Client;
+  let schemaService: ReturnType<typeof createTestSchemaService>;
+
+  beforeEach(async () => {
+    client = await createTestClient();
+    await cleanDatabase(client);
+    schemaService = createTestSchemaService();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(client);
+    await client.end();
+  });
+
+  const schemaV1 = `
+    CREATE TABLE users (
+      first_name VARCHAR(128) NOT NULL,
+      last_name VARCHAR(128) NOT NULL
+    );
+    CREATE INDEX full_name ON users ((first_name || ' ' || last_name));
+  `;
+
+  const schemaV2 = `
+    CREATE TABLE users (
+      first_name VARCHAR(128) NOT NULL,
+      last_name VARCHAR(128) NOT NULL
+    );
+    CREATE INDEX full_name ON users ((first_name || '''s first name'));
+  `;
+
+  test("v1: create and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV1, ["public"]);
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  test("v1->v2: apply changes and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV2, ["public"]);
+    console.log("Plan:", JSON.stringify(plan, null, 2));
+    expect(plan.hasChanges).toBe(true);
+
+    await schemaService.apply(schemaV2, ["public"], true);
+
+    const plan2 = await schemaService.plan(schemaV2, ["public"]);
+    expect(plan2.hasChanges).toBe(false);
+  });
+});

--- a/src/test/edge-cases/index-partial.test.ts
+++ b/src/test/edge-cases/index-partial.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Client } from "pg";
+import { createTestClient, cleanDatabase, createTestSchemaService } from "../utils";
+
+describe("Edge case: partial indexes with where clause", () => {
+  let client: Client;
+  let schemaService: ReturnType<typeof createTestSchemaService>;
+
+  beforeEach(async () => {
+    client = await createTestClient();
+    await cleanDatabase(client);
+    schemaService = createTestSchemaService();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(client);
+    await client.end();
+  });
+
+  const schemaV1 = `
+    CREATE TABLE users (
+      name TEXT NOT NULL,
+      active BOOLEAN
+    );
+    CREATE INDEX users_name ON users (name) WHERE active;
+  `;
+
+  const schemaV2 = `
+    CREATE TABLE users (
+      name TEXT NOT NULL,
+      active BOOLEAN
+    );
+    CREATE INDEX users_name ON users (name) WHERE active AND name <> '';
+  `;
+
+  test("v1: create and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV1, ["public"]);
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  test("v1->v2: apply changes and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV2, ["public"]);
+    console.log("Plan:", JSON.stringify(plan, null, 2));
+    expect(plan.hasChanges).toBe(true);
+
+    await schemaService.apply(schemaV2, ["public"], true);
+
+    const plan2 = await schemaService.plan(schemaV2, ["public"]);
+    expect(plan2.hasChanges).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix expression indexes with multiple operators (like `a || b || c`) not being fully wrapped in parentheses
- Add edge case tests for partial indexes and expression indexes

## Problem
Expression indexes like `(first_name || ' ' || last_name)` were incorrectly generated as `((first_name || ' ') || last_name)` due to operator associativity in the parser. The outer `|| last_name` ended up outside the parentheses, causing a syntax error.

## Solution
Always wrap expressions containing operators in parentheses, regardless of whether they already start with `(`. Extra parentheses are harmless and ensure correctness.

## Test plan
- [x] Added `index-partial.test.ts` - partial indexes with WHERE clauses (already worked)
- [x] Added `index-expr.test.ts` - expression indexes with string concatenation
- [x] All 1033 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)