### PR TITLE
fix: multi-column FK inspection and comparison

### DIFF
--- a/src/test/edge-cases/foreign-key.test.ts
+++ b/src/test/edge-cases/foreign-key.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Client } from "pg";
+import { createTestClient, cleanDatabase, createTestSchemaService } from "../utils";
+
+describe("Edge case: foreign key constraints", () => {
+  let client: Client;
+  let schemaService: ReturnType<typeof createTestSchemaService>;
+
+  beforeEach(async () => {
+    client = await createTestClient();
+    await cleanDatabase(client);
+    schemaService = createTestSchemaService();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(client);
+    await client.end();
+  });
+
+  const schemaV1 = `
+    CREATE TABLE t1 (
+      c1 INTEGER NOT NULL PRIMARY KEY,
+      c2 INTEGER,
+      c3 INTEGER
+    );
+    CREATE UNIQUE INDEX t1_c2_c3_idx ON t1 (c2, c3);
+
+    CREATE TABLE t2 (
+      c1 INTEGER NOT NULL PRIMARY KEY,
+      c2 INTEGER,
+      c3 INTEGER,
+      CONSTRAINT c2_c3_1 FOREIGN KEY (c2, c3) REFERENCES t1 (c2, c3),
+      CONSTRAINT c2_c3_2 FOREIGN KEY (c2, c3) REFERENCES t1 (c2, c3)
+    );
+  `;
+
+  test("v1: create and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV1, ["public"]);
+    expect(plan.hasChanges).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes FK inspection for multi-column foreign keys (was producing cartesian product)
- Fixes comparison logic for multiple FKs with same structure but different names
- Uses pg_constraint directly instead of information_schema for accurate results

## Test plan
- [x] New edge case test passes
- [x] All existing tests pass (1038 pass, 7 skip, 0 fail)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)