### PR TITLE
fix: timestamp/time precision type normalization

### DIFF
--- a/src/test/edge-cases/column-time-precision.test.ts
+++ b/src/test/edge-cases/column-time-precision.test.ts
@@ -1,0 +1,62 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Client } from "pg";
+import { createTestClient, cleanDatabase, createTestSchemaService } from "../utils";
+
+describe("Edge case: time/timestamp precision", () => {
+  let client: Client;
+  let schemaService: ReturnType<typeof createTestSchemaService>;
+
+  beforeEach(async () => {
+    client = await createTestClient();
+    await cleanDatabase(client);
+    schemaService = createTestSchemaService();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(client);
+    await client.end();
+  });
+
+  const schemaV1 = `
+    CREATE TABLE tbl (
+      precision_default TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      timestamp_4 TIMESTAMP(4) NOT NULL DEFAULT CURRENT_TIMESTAMP(4),
+      timestamptz_4 TIMESTAMPTZ(4) NOT NULL DEFAULT CURRENT_TIMESTAMP(4)
+    );
+  `;
+
+  const schemaV2 = `
+    CREATE TABLE tbl (
+      c1 TIMESTAMPTZ(1),
+      c2 TIMESTAMPTZ,
+      c3 TIMESTAMPTZ(0),
+      c4 TIME,
+      c5 TIME(1),
+      c6 TIMESTAMP,
+      c7 TIMESTAMP(5),
+      c8 TIMETZ(0),
+      c9 TIMETZ,
+      c10 TIMETZ(6)
+    );
+  `;
+
+  test("v1: create and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV1, ["public"]);
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  test("v1->v2: apply changes and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV2, ["public"]);
+    console.log("Plan:", JSON.stringify(plan, null, 2));
+    expect(plan.hasChanges).toBe(true);
+
+    await schemaService.apply(schemaV2, ["public"], true);
+
+    const plan2 = await schemaService.plan(schemaV2, ["public"]);
+    expect(plan2.hasChanges).toBe(false);
+  });
+});

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -117,6 +117,24 @@ export function normalizeType(type: string): string {
     }
   }
 
+  // Handle timestamp/time types with precision (format: "timestamp(4) without time zone")
+  const timestampMatch = type.match(/^timestamp\((\d+)\)\s+without\s+time\s+zone$/i);
+  if (timestampMatch) {
+    return `TIMESTAMP(${timestampMatch[1]})`;
+  }
+  const timestamptzMatch = type.match(/^timestamp\((\d+)\)\s+with\s+time\s+zone$/i);
+  if (timestamptzMatch) {
+    return `TIMESTAMPTZ(${timestamptzMatch[1]})`;
+  }
+  const timeMatch = type.match(/^time\((\d+)\)\s+without\s+time\s+zone$/i);
+  if (timeMatch) {
+    return `TIME(${timeMatch[1]})`;
+  }
+  const timetzMatch = type.match(/^time\((\d+)\)\s+with\s+time\s+zone$/i);
+  if (timetzMatch) {
+    return `TIMETZ(${timetzMatch[1]})`;
+  }
+
   // Normalize to lowercase first for case-insensitive matching
   const lowerType = type.toLowerCase();
   return typeMap[lowerType] || type.toUpperCase();


### PR DESCRIPTION
## Summary
- Normalizes timestamp/time types with precision for comparison
- Handles PostgreSQL's format_type output like "timestamp(4) without time zone"

## Test plan
- [x] New edge case test passes
- [x] All existing tests pass (1054 pass)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)