### PR TITLE
test: add edge case test for float/real/double precision types

### DIFF
--- a/src/test/edge-cases/column-float.test.ts
+++ b/src/test/edge-cases/column-float.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Client } from "pg";
+import { createTestClient, cleanDatabase, createTestSchemaService } from "../utils";
+
+describe("Edge case: float/real/double precision types", () => {
+  let client: Client;
+  let schemaService: ReturnType<typeof createTestSchemaService>;
+
+  beforeEach(async () => {
+    client = await createTestClient();
+    await cleanDatabase(client);
+    schemaService = createTestSchemaService();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase(client);
+    await client.end();
+  });
+
+  const schemaV1 = `
+    CREATE TABLE users (
+      c1 REAL,
+      c2 DOUBLE PRECISION,
+      c3 FLOAT(10),
+      c4 FLOAT(30)
+    );
+  `;
+
+  const schemaV2 = `
+    CREATE TABLE users (
+      c1 DOUBLE PRECISION,
+      c2 REAL,
+      c3 FLOAT(30),
+      c4 FLOAT(10)
+    );
+  `;
+
+  test("v1: create and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV1, ["public"]);
+    expect(plan.hasChanges).toBe(false);
+  });
+
+  test("v1->v2: apply changes and verify idempotency", async () => {
+    await schemaService.apply(schemaV1, ["public"], true);
+
+    const plan = await schemaService.plan(schemaV2, ["public"]);
+    console.log("Plan:", JSON.stringify(plan, null, 2));
+    expect(plan.hasChanges).toBe(true);
+
+    await schemaService.apply(schemaV2, ["public"], true);
+
+    const plan2 = await schemaService.plan(schemaV2, ["public"]);
+    expect(plan2.hasChanges).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds test for REAL, DOUBLE PRECISION, and FLOAT with precision
- Tests type changes between float variants

## Test plan
- [x] Test passes locally
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)