### PR TITLE
fix: external sql.js and libsql to fix npm install runtime errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "dev": "bun run --watch src/index.ts",
-    "build": "bun build src/index.ts --outdir ./dist --target node --external libpg-query",
+    "build": "bun build src/index.ts --outdir ./dist --target node --external libpg-query --external sql.js --external libsql",
     "prepublishOnly": "bun run build",
     "apply": "bun run src/index.ts apply",
     "test": "bun --env-file=.env test src/test/tables.test.ts src/test/columns/constraints/ src/test/columns/core-operations/ src/test/columns/edge-cases/ src/test/columns/type-conversions/ src/test/indexes/ src/test/utils.ts",


### PR DESCRIPTION
## Summary
- External sql.js and libsql from bundle to fix hardcoded CI build paths
- Fixes ENOENT errors when running terradb installed via npm

## Problem
The bundle was embedding hardcoded paths from the CI build environment for sql.js wasm files:
```
ENOENT: no such file or directory, open '/home/runner/work/terradb/terradb/node_modules/sql.js/dist/sql-wasm.wasm'
```

## Solution
By externalizing sql.js and libsql from the bundle (using `--external` flag), these modules are loaded from node_modules at runtime, fixing the path resolution issue.

## Test plan
- [x] Verified fix locally by packing and installing via npm
- [x] All tests pass

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)